### PR TITLE
Fixed 'runtime_error’ is not a member of ‘std’

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -4,6 +4,7 @@
 #include <sys/stat.h>
 #include <pwd.h>
 #include <exception>
+#include <stdexcept>
 
 std::string util::dirname(const std::string& path)
 {


### PR DESCRIPTION
src/util.cpp had a missing import, causing the error mentioned above.